### PR TITLE
Copy the whole bundle as is in makeself backend

### DIFF
--- a/src/oui_lib/sh_script.ml
+++ b/src/oui_lib/sh_script.ml
@@ -27,6 +27,7 @@ type command =
   | Symlink of {target: string; link: string}
   | Set_permissions_in of
       {on: find_type; permissions: int; starting_point: string}
+  | Copy_all_in of {src: string; dst: string; except: string}
   | If of {condition : condition; then_ : command list}
   | Prompt of {question: string; varname: string}
   | Case of {varname: string; cases: case list}
@@ -51,6 +52,8 @@ let case varname cases = Case {varname; cases}
 
 let set_permissions_in ~on ~permissions starting_point =
   Set_permissions_in {on; permissions; starting_point}
+
+let copy_all_in ~src ~dst ~except = Copy_all_in {src; dst; except}
 
 let pp_sh_find_type fmtr ft =
   match ft with
@@ -83,6 +86,10 @@ let rec pp_sh_command ~indent fmtr command =
       starting_point
       pp_sh_find_type on
       permissions
+  | Copy_all_in {src; dst; except} ->
+    fpf
+      "find %s -mindepth 1 -maxdepth 1 ! -name '%s' -exec cp -rp {} %s \\;"
+      src except dst
   | If {condition; then_} ->
     fpf "if [ %a ]; then" pp_sh_condition condition;
     List.iter (pp_sh_command ~indent:(indent + 2) fmtr) then_;

--- a/src/oui_lib/sh_script.mli
+++ b/src/oui_lib/sh_script.mli
@@ -27,6 +27,7 @@ type command =
   | Symlink of {target: string; link: string}
   | Set_permissions_in of
       {on: find_type; permissions: int; starting_point: string}
+  | Copy_all_in of {src: string; dst: string; except: string}
   | If of {condition : condition; then_ : command list}
   | Prompt of {question: string; varname: string}
   | Case of {varname: string; cases: case list}
@@ -74,6 +75,8 @@ val if_ : condition -> command list -> command
 (** [set_permissions_in starting_point ~on ~permissions] is
     ["find starting_point -type find_type -exec chmod permissions {} +"] *)
 val set_permissions_in : on: find_type -> permissions: int -> string -> command
+
+val copy_all_in : src: string -> dst: string -> except: string -> command
 
 (** [promt ~question ~varname] is ["printf \"question \""] followed by
     [read varname]. *)

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -50,18 +50,12 @@ let%expect_test "install_script: one binary" =
       echo "Please run again as root."
       exit 1
     fi
-    mkdir -p /opt/aaa /opt/aaa/bin
-    cp aaa-command /opt/aaa/bin
-    cp aaa-utility /opt/aaa/bin
-    find /opt/aaa -type d -exec chmod 755 {} +
-    find /opt/aaa -type f -exec chmod 644 {} +
-    find /opt/aaa/bin -type f -exec chmod 755 {} +
+    mkdir -p -m 755 /opt/aaa
+    find . -mindepth 1 -maxdepth 1 ! -name 'install.sh' -exec cp -rp {} /opt/aaa \;
     echo "Adding aaa-command to /usr/local/bin"
-    ln -s /opt/aaa/bin/aaa-command /usr/local/bin/aaa-command
+    ln -s /opt/aaa/aaa-command /usr/local/bin/aaa-command
     echo "Adding aaa-utility to /usr/local/bin"
-    ln -s /opt/aaa/bin/aaa-utility /usr/local/bin/aaa-utility
-    cp uninstall.sh /opt/aaa
-    chmod 755 /opt/aaa/uninstall.sh
+    ln -s /opt/aaa/aaa-utility /usr/local/bin/aaa-utility
     echo "Installation complete!"
     echo "If you want to safely uninstall aaa, please run /opt/aaa/uninstall.sh."
     |}]


### PR DESCRIPTION
The makeself backend will now archive the whole install bundle and copy all files and directories into `/opt/<appname>`, preserving the same structure and permissions.

This gives a bit more freedom to `oui` users and simplifies the installation script.