### PR TITLE
Fix non root binaries installation in makeself backend

### DIFF
--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -8,6 +8,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+let (/) = Filename.concat
 let install_script_name = "install.sh"
 let uninstall_script_name = "uninstall.sh"
 let man_dst = "MAN_DEST"
@@ -42,9 +43,17 @@ let set_man_dest =
 
 let add_symlink ~prefix ~in_ bundle_path =
   let open Sh_script in
-  let (/) = Filename.concat in
   let base = Filename.basename bundle_path in
   symlink ~target:(prefix / bundle_path) ~link:(in_ / base)
+
+let remove_symlink ?(name="symlink") ~in_ bundle_path =
+  let open Sh_script in
+  let link = in_ / (Filename.basename bundle_path) in
+  if_ (Link_exists link)
+    [ echof "Removing %s %s..." name link
+    ; rm [link]
+    ]
+    ()
 
 let manpages_to_list (mnpgs : Installer_config.manpages option) =
   match mnpgs with
@@ -53,7 +62,6 @@ let manpages_to_list (mnpgs : Installer_config.manpages option) =
 
 let install_manpages ~prefix manpages =
   let open Sh_script in
-  let (/) = Filename.concat in
   let install_page ~section page = add_symlink ~prefix ~in_:section page in
   match manpages with
   | [] -> []
@@ -72,7 +80,6 @@ let install_manpages ~prefix manpages =
 
 let install_script (ic : Installer_config.t) =
   let open Sh_script in
-  let (/) = Filename.concat in
   let package = ic.name in
   let version = ic.version in
   let prefix = "/opt" / package in
@@ -158,29 +165,12 @@ let uninstall_script (ic : Installer_config.t) =
         ()
     ]
   in
-  let remove_symlinks =
-    List.map
-      (fun binary ->
-         let link = usrbin / binary in
-         if_ (Link_exists link)
-           [ echof "Removing symlink %s..." link
-           ; rm [link]
-           ]
-           ()
-      )
-      binaries
-  in
+  let remove_symlinks = List.map (remove_symlink ~in_:usrbin) binaries in
   let remove_manpages =
     List.concat_map
       (fun (section, pages) ->
          List.map
-           (fun page ->
-              let path = man_dst_var / section / (Filename.basename page) in
-              if_ (Link_exists path)
-                [ echof "Removing manpage %s..." path
-                ; rm [path]
-                ]
-                ())
+           (remove_symlink ~name:"manpage" ~in_:(man_dst_var / section))
            pages)
       manpages
   in

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -226,9 +226,9 @@ let%expect_test "uninstall_script: binary in sub folder" =
       echo "Removing /opt/name..."
       rm -rf /opt/name
     fi
-    if [ -L "/usr/local/bin/bin/do" ]; then
-      echo "Removing symlink /usr/local/bin/bin/do..."
-      rm -f /usr/local/bin/bin/do
+    if [ -L "/usr/local/bin/do" ]; then
+      echo "Removing symlink /usr/local/bin/do..."
+      rm -f /usr/local/bin/do
     fi
     echo "Uninstallation complete!"
     |}]


### PR DESCRIPTION
This fixes a bug where binaries that weren't at the root of the install bundle trigger an installation script failure as it failed to properly create the symlinks in `/usr/local/bin`.