### PR TITLE
Add opam-core 2.4 dependecy

### DIFF
--- a/oui.opam
+++ b/oui.opam
@@ -18,6 +18,7 @@ depends: [
   "crunch" {>= "3.3.1"}
   "opam-client" {>= "2.4" & = opam-version}
   "opam-format" {>= "2.4" & = opam-version}
+  "opam-core" {>= "2.4" & = opam-version}
   "fmt"
   "yojson"
   "ppx_deriving_yojson"


### PR DESCRIPTION
The type of [OpamFilename.dir_is_empty has changed in 2.4.0](https://github.com/ocaml/opam/pull/6490/files#diff-34e692a7b7abc0833973e30f43afe40ccdab11ae661ed38c28042a74cf749a17R55)

And is used in

https://github.com/OCamlPro/ocaml-universal-installer/blob/master/src/oui_lib/opam_frontend.ml#L352