### PR TITLE
Remove CLI options that are specified in config/JSON file

### DIFF
--- a/oui.opam
+++ b/oui.opam
@@ -14,7 +14,6 @@ depends: [
   "ocaml" {build & >= "4.11.0"}
   "dune" {build & >= "3.2"}
   "cmdliner" {>= "1.3"}
-  "markup"
   "crunch" {>= "3.3.1"}
   "opam-client" {>= "2.4" & = opam-version}
   "opam-format" {>= "2.4" & = opam-version}

--- a/src/oui_cli/args.ml
+++ b/src/oui_cli/args.ml
@@ -11,14 +11,6 @@
 open Cmdliner
 open Cmdliner.Arg
 open Oui
-open Oui.Types
-
-let wix_version_conv =
-  let parse str =
-    try `Ok (Wix.Version.of_string str) with Failure s -> `Error s
-  in
-  let print ppf wxv = Format.pp_print_string ppf (Wix.Version.to_string wxv) in
-  (parse, print)
 
 let opam_filename =
   let conv, pp = OpamArg.filename in
@@ -28,7 +20,7 @@ let opam_dirname =
   let conv, pp = OpamArg.dirname in
   ((fun dirname_arg -> System.normalize_path dirname_arg |> conv), pp)
 
-let conffile =
+let conf_file =
   value
   & opt (some opam_filename) None
   & info [ "conf"; "c" ] ~docv:"PATH" ~docs:Man.Section.bin_args
@@ -36,76 +28,16 @@ let conffile =
         "Configuration file for the binary to install. See $(i,Configuration) \
          section"
 
-let wix_version =
-  value
-  & opt (some wix_version_conv) None
-  & info [ "with-version" ] ~docv:"VERSION"
-      ~doc:
-        "The version to use for the installer, in an msi format, i.e. numbers \
-         and dots, [0-9.]+"
-
-let wix_path =
-  (* FIXME: that won't work when using a MinGW ocaml compiler under a Cygwin env... *)
-  (* NOTE1: we could retrieve this using the WIX6 environment variable *)
-  (* NOTE2: or we could rely in wix.exe to be in the PATH (the installer sets it) *)
-  let prefix = if Sys.cygwin || true then "/cygdrive" else "" in
-  value
-  & opt string (prefix ^ "/c/Program Files/WiX Toolset v6.0/bin")
-  & info [ "wix-path" ] ~docv:"DIR"
-      ~doc:
-        "The path where WIX tools are stored. The path should be full and \
-         should use linux format path (with $(i,/) as delimiter) since \
-         presence of such binaries are checked with $(b,which) tool that \
-         accepts only this type of path."
-
-let package_guid =
-  value
-  & opt (some string) None
-  & info [ "pkg-guid" ] ~docv:"UID"
-      ~doc:
-        "The package GUID that will be used to update the same package with \
-         different version without processing throught Windows Apps & features \
-         panel."
-
-let icon_file =
-  value
-  & opt (some OpamArg.filename) None
-  & info [ "ico" ] ~docv:"FILE"
-      ~doc:"Logo icon that will be used for application."
-
-let dlg_bmp =
-  value
-  & opt (some OpamArg.filename) None
-  & info [ "dlg-bmp" ] ~docv:"FILE"
-      ~doc:
-        "BMP file that is used as background for dialog window for installer."
-
-let ban_bmp =
-  value
-  & opt (some OpamArg.filename) None
-  & info [ "ban-bmp" ] ~docv:"FILE"
-      ~doc:"BMP file that is used as background for banner for installer."
-
-let keep_wxs = value & flag & info [ "keep-wxs" ] ~doc:"Keep Wix source files."
+let wix_keep_wxs = value & flag & info [ "keep-wxs" ] ~doc:"Keep Wix source files."
 
 let config =
-  let apply conf_file conf_wix_version
-      conf_wix_path conf_package_guid conf_icon_file
-      conf_dlg_bmp conf_ban_bmp conf_keep_wxs =
-    {
+  let apply conf_file conf_wix_keep_wxs =
+    Config.{
       conf_file;
-      conf_wix_version;
-      conf_wix_path;
-      conf_package_guid;
-      conf_icon_file;
-      conf_dlg_bmp;
-      conf_ban_bmp;
-      conf_keep_wxs;
+      conf_wix_keep_wxs;
     }
   in
-  Term.(
-    const apply $ conffile $ wix_version
-    $ wix_path $ package_guid $ icon_file $ dlg_bmp $ ban_bmp $ keep_wxs)
+  Term.(const apply $ conf_file $ wix_keep_wxs)
 
 type backend = Wix | Makeself
 

--- a/src/oui_cli/args.mli
+++ b/src/oui_cli/args.mli
@@ -11,7 +11,7 @@
 val opam_filename : OpamFilename.t Cmdliner.Arg.conv
 val opam_dirname : OpamFilename.Dir.t Cmdliner.Arg.conv
 
-val config : Oui.Types.config Cmdliner.Term.t
+val config : Oui.Config.config Cmdliner.Term.t
 (** Cmdliner term evaluating to the config compiled from relevant CLI args and
     options. Note that this consumes the first positional argument. *)
 

--- a/src/oui_lib/config.ml
+++ b/src/oui_lib/config.ml
@@ -8,20 +8,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open OpamTypes
-
 type config = {
   conf_file: OpamFilename.t option;
-  conf_wix_version: Wix.Version.t option;
-  conf_wix_path : string;
-  conf_package_guid: string option;
-  conf_icon_file : filename option;
-  conf_dlg_bmp : filename option;
-  conf_ban_bmp : filename option;
-  conf_keep_wxs : bool;
+  conf_wix_keep_wxs : bool;
 }
-
-type embedded =
-  | Copy_alias of string * string
-  | Copy_external of string
-  | Copy_opam of string

--- a/src/oui_lib/dune
+++ b/src/oui_lib/dune
@@ -11,7 +11,7 @@
 (library
  (name oui)
  (public_name oui.lib)
- (libraries fmt opam-format opam-client markup unix yojson)
+ (libraries fmt opam-format opam-client unix yojson)
  (preprocess
   (pps ppx_deriving_yojson)))
 

--- a/src/oui_lib/installer_config.ml
+++ b/src/oui_lib/installer_config.ml
@@ -51,7 +51,6 @@ type t = {
     manufacturer : string;
     exec_files : string list;
     makeself_manpages : manpages option; [@default None]
-    wix_guid : string option; [@default None]
     wix_tags : string list; [@default []]
     wix_icon_file : string option; [@default None]
     wix_dlg_bmp_file : string option; [@default None]

--- a/src/oui_lib/installer_config.mli
+++ b/src/oui_lib/installer_config.mli
@@ -32,17 +32,13 @@ type t = {
     (** Product manufacturer. Deduced from field {i maintainer} in opam file *)
     exec_files : string list; (** Filenames of bundled .exe binary. *)
     makeself_manpages : manpages option; (** Paths to manpages, split by sections. *)
-    wix_guid : string option;
-    (** Package UID, used by WiX backend. Should be equal for every version of
-        given package. If not specified, generated new UID *)
     wix_tags : string list; (** Package tags, used by WiX. *)
     wix_icon_file : string option;
     (** Icon filename, used by WiX. Defaults to our data/images/logo.ico file. *)
     wix_dlg_bmp_file : string option;
     (** Dialog bmp filename, used by WiX. Default to our data/images/dlgbmp.bmp *)
     wix_banner_bmp_file : string option;
-    (* Banner bmp filename, used by WiX. Defaults to our
-       data/images/bannrbmp.bmp *)
+    (** Banner bmp filename, used by WiX. Defaults to our data/images/bannrbmp.bmp *)
     wix_license_file : string option;
     wix_embedded_dirs : (OpamFilename.Base.t * OpamFilename.Dir.t) list;
     (** Embedded directories information (reference another wxs file) *)

--- a/src/oui_lib/opam_conf_file.ml
+++ b/src/oui_lib/opam_conf_file.ml
@@ -18,16 +18,17 @@ module Syntax = struct
   type images = { ico: string option; dlg: string option; ban: string option }
   type t = {
     c_version: OpamVersion.t;
+    c_wix_version: Wix.Version.t option;
     c_images: images;
     c_binary_path: string option;
     c_binary: string option;
-    c_wix_version: Wix.Version.t option;
     c_embedded : (string * string option) list;
     c_envvar: (string * string) list;
   }
 
   let empty = {
     c_version = format_version;
+    c_wix_version = None;
     c_images = {
       ico = None;
       dlg = None;
@@ -35,7 +36,6 @@ module Syntax = struct
     };
     c_binary_path = None;
     c_binary = None;
-    c_wix_version = None;
     c_embedded = [];
     c_envvar = [];
   }
@@ -57,6 +57,10 @@ module Syntax = struct
     "opamwix-version", OpamPp.ppacc
       (fun c_version t -> { t with c_version}) (fun t -> t.c_version)
       (OpamFormat.V.string -| OpamPp.of_module "version" (module OpamVersion));
+    "wix-version", OpamPp.ppacc_opt
+      (fun c_wix_version t -> { t with c_wix_version = Some c_wix_version })
+      (fun t -> t.c_wix_version)
+      (OpamFormat.V.string -| OpamPp.of_module "wix_version" (module Wix.Version));
     "ico", OpamPp.ppacc_opt
       (fun ico t -> { t with c_images = { t.c_images with ico = Some ico } })
       (fun t -> t.c_images.ico)
@@ -76,10 +80,6 @@ module Syntax = struct
     "binary", OpamPp.ppacc_opt
       (fun binary t -> { t with c_binary = Some binary }) (fun t -> t.c_binary)
       OpamFormat.V.string;
-    "wix-version", OpamPp.ppacc_opt
-      (fun c_wix_version t -> { t with c_wix_version = Some c_wix_version })
-      (fun t -> t.c_wix_version)
-      (OpamFormat.V.string -| OpamPp.of_module "wix_version" (module Wix.Version));
     "embedded", OpamPp.ppacc
       (fun file t -> { t with c_embedded = file }) (fun t -> t.c_embedded)
       (OpamFormat.V.map_list ~depth:2 embedded_pp);

--- a/src/oui_lib/opam_conf_file.mli
+++ b/src/oui_lib/opam_conf_file.mli
@@ -27,10 +27,10 @@ module Conf: sig
   (** Content of config file *)
   type t = {
     c_version: OpamVersion.t; (* Config file version *)
+    c_wix_version: Wix.Version.t option; (* Wix compatible version to use for install *)
     c_images: images; (* Images files that are treated not as other embedded files *)
     c_binary_path: string option; (* Path to binary to install *)
     c_binary: string option; (* Binary name to install *)
-    c_wix_version: Wix.Version.t option; (* Wix compatible version to use for install *)
     c_embedded : (string * string option) list; (* Files/directories to embed in installation directory *)
     c_envvar: (string * string) list; (* Environement variables to set in Windows Terminal on installation *)
   }

--- a/src/oui_lib/opam_frontend.mli
+++ b/src/oui_lib/opam_frontend.mli
@@ -11,9 +11,9 @@
 val with_install_bundle :
   OpamCLIVersion.Sourced.t ->
   OpamArg.global_options ->
-  Types.config ->
+  Config.config ->
   OpamTypes.name ->
-  (Types.config ->
+  (Config.config ->
    Installer_config.t ->
    bundle_dir:OpamFilename.Dir.t ->
    tmp_dir:OpamFilename.Dir.t -> unit) ->

--- a/src/oui_lib/system.ml
+++ b/src/oui_lib/system.ml
@@ -8,12 +8,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type uuid_mode =
-  | Rand
-  | Exec of string * string * string option
-
 type wix = {
-  wix_wix_path : string;
   wix_files : string list;
   wix_exts : string list;
   wix_out : string
@@ -57,8 +52,8 @@ let call_inner : type a. a command -> a -> string * string list =
       | `CygAbs -> "-ua"
     in
     "cygpath", [ opts; path ]
-  | Wix, {wix_wix_path; wix_files; wix_exts; wix_out} ->
-    let wix = Filename.concat wix_wix_path "wix.exe" in
+  | Wix, { wix_files; wix_exts; wix_out } ->
+    let wix = "wix.exe" in
     let args = "build" ::
       List.flatten (List.map (fun e -> ["-ext"; e]) wix_exts)
       @ wix_files @ ["-o"; wix_out]
@@ -145,21 +140,6 @@ let path_str path =
     |> String.concat "/"
   else
     OpamFilename.to_string path
-
-let check_available_commands wix_path =
-  let wix_bin_exists bin =
-    Sys.file_exists @@ Filename.concat wix_path bin
-  in
-  if wix_bin_exists "wix.exe"
-  then
-    call_list [
-      Which, "cygcheck";
-      Which, "cygpath";
-      Which, "uuidgen";
-    ]
-  else
-    raise @@ System_error
-      (Format.sprintf "Wix binaries couldn't be found in %s directory." wix_path)
 
 open OpamTypes
 

--- a/src/oui_lib/system.mli
+++ b/src/oui_lib/system.mli
@@ -12,15 +12,9 @@
     Contains command's output. *)
 exception System_error of string
 
-(** Configuration option for {i uuidgen} command used as a seed for generator. *)
-type uuid_mode =
-  | Rand (** Random seed *)
-  | Exec of string * string * string option (** Seed based on metadata information about package, its version and name of binary. *)
-
-(** Configuration options for {i wix} command as a part of WiX tools. Consists of the path to
-    WiX toolset binaries, input files, extensions to be used and output file path. *)
+(** Configuration options for {i wix} command as a part of WiX tools.
+    Consists of input files, extensions to be used and output file path. *)
 type wix = {
-  wix_wix_path : string;
   wix_files : string list;
   wix_exts : string list;
   wix_out : string
@@ -61,9 +55,6 @@ val call_unit : 'a command -> 'a -> unit
 
 (** Same as [call_unit], but calls commands simultaneously. *)
 val call_list : ('a command * 'a) list -> unit
-
-(** Checks if all handled commands are available system-widely. *)
-val check_available_commands : string -> unit
 
 (** Performs path translations between Windows and Cygwin. See [System.cygpath_out] for more details. *)
 val cyg_win_path : cygpath_out -> string -> string

--- a/src/oui_lib/wix_backend.mli
+++ b/src/oui_lib/wix_backend.mli
@@ -11,7 +11,7 @@
 val create_bundle :
   tmp_dir:OpamFilename.Dir.t ->
   bundle_dir:OpamFilename.Dir.t ->
-  Types.config ->
+  Config.config ->
   Installer_config.t ->
   OpamFilename.t ->
   unit

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -37,7 +37,6 @@ let make_config
   ; description = ""
   ; manufacturer = ""
   ; makeself_manpages
-  ; wix_guid = None
   ; wix_tags = []
   ; wix_icon_file = None
   ; wix_dlg_bmp_file = None


### PR DESCRIPTION
This PR removes CLI options (WiX-specific), which can otherwise be specific using the (legacy) config file or the JSON file.