### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,10 +90,13 @@ jobs:
         run: opam install ocp-indent.1.8.1
 
       - name: "Test: create package"
-        run: opam exec -- opam-oui --keep-wxs ocp-indent
+        run: |
+          $env:PATH = $env:WIX6 + ";" + $env:PATH
+          opam exec -- opam-oui --keep-wxs ocp-indent
 
       - name: "Test: install package"
-        run: msiexec /i ocp-indent.1.8.1.msi /qn /L*v wixlog.txt ALLUSERS=2 MSIINSTALLPERUSER=
+        run: |
+          msiexec /i ocp-indent-1.8.1.msi /qn /L*v wixlog.txt ALLUSERS=2 MSIINSTALLPERUSER= 
 
       - name: "Test: execute binary"
         run: |
@@ -112,3 +115,10 @@ jobs:
         with:
           name: wixlog.txt
           path: wixlog.txt
+
+      - name: Upload package.msi
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: package.msi
+          path: ocp-indent-1.8.1.msi

--- a/src/oui_lib/wix_backend.ml
+++ b/src/oui_lib/wix_backend.ml
@@ -10,7 +10,7 @@
 
 let check_wix_installed () =
   let wix_bin_exists () =
-    match Sys.command "wix --version" with
+    match Sys.command "wix.exe --version" with
     | 0 -> true
     | _ -> false
   in


### PR DESCRIPTION
This fixes the Windows CI.

Two things suddently stopped working and had to be fixed:
- the PATH variable is supposed to be augmented with the directory where the WiX binaries are installed ; however for some reason the WiX installer randomly fails to do so ; to solve this I added instructions to force this directory to be added to the PATH
- the test MSI package was previously named `ocp-indent.1.8.1.msi`, it is now named `ocp-indent-1.8.1.msi` (a dot turned into an hyphen) ; I couldn't find why this occurred ; to solve this I just updated the file name in the workflow