### PR TITLE
Embed .so next to binaries and properly set their RPATH

### DIFF
--- a/src/oui_lib/makeself_backend.ml
+++ b/src/oui_lib/makeself_backend.ml
@@ -183,13 +183,14 @@ let uninstall_script (ic : Installer_config.t) =
   @ notify_uninstall_complete
 
 let add_sos_to_bundle ~bundle_dir binary =
-  let sos = Ldd.get_sos OpamFilename.Op.(bundle_dir // binary) in
+  let binary = OpamFilename.Op.(bundle_dir // binary) in
+  let sos = Ldd.get_sos binary in
   match sos with
   | [] -> ()
   | _ ->
-    let lib_dir = OpamFilename.Op.(bundle_dir / "lib") in
-    OpamFilename.mkdir lib_dir;
-    List.iter (fun so -> OpamFilename.copy_in so lib_dir) sos
+    let dst_dir = OpamFilename.dirname binary in
+    List.iter (fun so -> OpamFilename.copy_in so dst_dir) sos;
+    System.call_unit Patchelf (Set_rpath {rpath = "$ORIGIN"; binary})
 
 let create_installer
     ~(installer_config : Installer_config.t) ~bundle_dir installer =

--- a/src/oui_lib/system.ml
+++ b/src/oui_lib/system.ml
@@ -56,6 +56,9 @@ type productbuild_args = {
   output : OpamFilename.t;
 }
 
+type patchelf_args =
+  | Set_rpath of {rpath: string; binary: OpamFilename.t}
+
 type _ command =
   | Which : string command
   | Cygcheck : string command
@@ -70,6 +73,7 @@ type _ command =
   | CodesignVerify : codesign_verify_args command
   | Pkgbuild : pkgbuild_args command
   | Productbuild : productbuild_args command
+  | Patchelf : patchelf_args command
 
 exception System_error of string
 
@@ -144,6 +148,8 @@ let call_inner : type a. a command -> a -> string * string list =
       "--package"; OpamFilename.to_string package;
       OpamFilename.to_string output
     ]
+  | Patchelf, (Set_rpath {rpath; binary}) ->
+    "patchelf", ["--set-rpath"; rpath; OpamFilename.to_string binary]
 
 let gen_command_tmp_dir cmd =
   Printf.sprintf "%s-%06x" (Filename.basename cmd) (Random.int 0xFFFFFF)

--- a/src/oui_lib/system.mli
+++ b/src/oui_lib/system.mli
@@ -74,6 +74,10 @@ type productbuild_args = {
   output : OpamFilename.t; (** Output .pkg file *)
 }
 
+(** Arguments for patchelf command *)
+type patchelf_args =
+  | Set_rpath of {rpath: string; binary: OpamFilename.t}
+
 (** External commands that could be called and handled by {b oui}. *)
 type _ command =
   | Which : string command  (** {b which} command, to check programs availability *)
@@ -89,6 +93,7 @@ type _ command =
   | CodesignVerify : codesign_verify_args command (** {b codesign --verify} command to verify code signatures *)
   | Pkgbuild : pkgbuild_args command (** {b pkgbuild} command to create macOS component packages *)
   | Productbuild : productbuild_args command (** {b productbuild} command to create macOS installer packages *)
+  | Patchelf : patchelf_args command
 
 (** Calls given command with its arguments and parses output, line by line. Raises [System_error]
     with command's output when command exits with non-zero exit status. *)


### PR DESCRIPTION
This now copies shared libraries next to the binary itself and sets the binary `RUNPATH` to `$ORIGIN`.

I tested this locally with `LD_DEBUG=libs` and it seems to work just fine as they do get picked:
```
$ LD_DEBUG=libs alt-ergo
    806019:	find library=libz.so.1 [0]; searching
    806019:	 search path=/opt/alt-ergo/bin/glibc-hwcaps/x86-64-v3:/opt/alt-ergo/bin/glibc-hwcaps/x86-64-v2:/opt/alt-ergo/bin/tls/haswell/x86_64:/opt/alt-ergo/bin/tls/haswell:/opt/alt-ergo/bin/tls/x86_64:/opt/alt-ergo/bin/tls:/opt/alt-ergo/bin/haswell/x86_64:/opt/alt-ergo/bin/haswell:/opt/alt-ergo/bin/x86_64:/opt/alt-ergo/bin		(RUNPATH from file alt-ergo)
    806019:	  trying file=/opt/alt-ergo/bin/glibc-hwcaps/x86-64-v3/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/glibc-hwcaps/x86-64-v2/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/tls/haswell/x86_64/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/tls/haswell/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/tls/x86_64/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/tls/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/haswell/x86_64/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/haswell/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/x86_64/libz.so.1
    806019:	  trying file=/opt/alt-ergo/bin/libz.so.1
    806019:	
    806019:	find library=libgmp.so.10 [0]; searching
    806019:	 search path=/opt/alt-ergo/bin		(RUNPATH from file alt-ergo)
    806019:	  trying file=/opt/alt-ergo/bin/libgmp.so.10
    806019:	
    806019:	find library=libm.so.6 [0]; searching
    806019:	 search path=/opt/alt-ergo/bin		(RUNPATH from file alt-ergo)
    806019:	  trying file=/opt/alt-ergo/bin/libm.so.6
    806019:	 search cache=/etc/ld.so.cache
    806019:	  trying file=/lib/x86_64-linux-gnu/libm.so.6
```

A quick side note on `RUNPATH` vs `RPATH` for future reference:

`RPATH` is checked before `LD_LIBRARY_PATH` while `RUNPATH` is checked after, allowing it to be overridden. If both are set, RPATH is ignored in favor of `RUNPATH`. `RPATH` appears to be deprecated and discouraged, in favor of `RUNPATH` specifically because the latter has lower priority than `LD_LIBRARY_PATH`. Following those recommendation I settled for `RUNPATH`. If we ever want to change that, we need to pass `--force-rpath` to `patchelf`.

It's also worth noting that some applications that I have installed on my machine, namely Zulip and Obsidian, use `RPATH`.