### PR TITLE
Remove no longer used fields from Installer_config.t

### DIFF
--- a/src/oui_lib/installer_config.ml
+++ b/src/oui_lib/installer_config.ml
@@ -8,29 +8,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Yojsonable = struct
-  type dirname = OpamFilename.Dir.t
-
-  let dirname_to_yojson dir = `String (OpamFilename.Dir.to_string dir)
-  let dirname_of_yojson = function
-    | `String dir -> Ok (OpamFilename.Dir.of_string dir)
-    | _ -> Error "Invalid OpamFilename.Dir.t JSON encoding"
-
-  type filename = OpamFilename.t
-
-  let filename_to_yojson fn = `String (OpamFilename.to_string fn)
-  let filename_of_yojson = function
-    | `String fn -> Ok (OpamFilename.of_string fn)
-    | _ -> Error "Invalid OpamFilename.t JSON encoding"
-
-  type basename = OpamFilename.Base.t
-
-  let basename_to_yojson bn = `String (OpamFilename.Base.to_string bn)
-  let basename_of_yojson = function
-    | `String bn -> Ok (OpamFilename.Base.of_string bn)
-    | _ -> Error "Invalid OpamFilename.Base.t JSON encoding"
-end
-
 type manpages =
   { man1 : string list [@default []]
   ; man2 : string list [@default []]
@@ -51,16 +28,12 @@ type t = {
     manufacturer : string;
     exec_files : string list;
     manpages : manpages option; [@default None]
+    environment : (string * string) list; [@default []]
     wix_tags : string list; [@default []]
     wix_icon_file : string option; [@default None]
     wix_dlg_bmp_file : string option; [@default None]
     wix_banner_bmp_file : string option; [@default None]
     wix_license_file : string option; [@default None]
-    wix_embedded_dirs : (Yojsonable.basename * Yojsonable.dirname) list; [@default []]
-    wix_additional_embedded_name : string list; [@default []]
-    wix_additional_embedded_dir : Yojsonable.dirname list; [@default []]
-    wix_embedded_files : (Yojsonable.basename * Yojsonable.filename) list; [@default []]
-    wix_environment : (string * string) list; [@default []]
     macos_bundle_id : string option; [@default None]
     macos_symlink_dirs : string list; [@default []]
   }

--- a/src/oui_lib/installer_config.mli
+++ b/src/oui_lib/installer_config.mli
@@ -32,6 +32,8 @@ type t = {
     (** Product manufacturer. Deduced from field {i maintainer} in opam file *)
     exec_files : string list; (** Filenames of bundled .exe binary. *)
     manpages : manpages option; (** Paths to manpages, split by sections. *)
+    environment : (string * string) list;
+    (** Environement variables to set/unset in Windows terminal on install/uninstall respectively. *)
     wix_tags : string list; (** Package tags, used by WiX. *)
     wix_icon_file : string option;
     (** Icon filename, used by WiX. Defaults to our data/images/logo.ico file. *)
@@ -40,14 +42,6 @@ type t = {
     wix_banner_bmp_file : string option;
     (** Banner bmp filename, used by WiX. Defaults to our data/images/bannrbmp.bmp *)
     wix_license_file : string option;
-    wix_embedded_dirs : (OpamFilename.Base.t * OpamFilename.Dir.t) list;
-    (** Embedded directories information (reference another wxs file) *)
-    wix_additional_embedded_name : string list ;
-    wix_additional_embedded_dir : OpamFilename.Dir.t list;
-    wix_embedded_files : (OpamFilename.Base.t * OpamTypes.filename) list;
-    (** Embedded files *)
-    wix_environment : (string * string) list;
-    (** Environement variables to set/unset in Windows terminal on install/uninstall respectively. *)
     macos_bundle_id : string option;
     (** macOS bundle identifier (reverse DNS format). *)
     macos_symlink_dirs : string list;

--- a/src/oui_lib/opam_frontend.ml
+++ b/src/oui_lib/opam_frontend.ml
@@ -339,17 +339,6 @@ let create_bundle ~global_state ~switch_state ~env ~tmp_dir opam_oui_conf
       ([],[])
       emb_modes
   in
-  let additional_embedded_name, additional_embedded_dir =
-    let opam_base, opam_dir =
-      match OpamFilename.dir_is_empty opam_dir with
-      | None | Some (true) -> [], []
-      | Some (false) -> ["opam"], [ opam_dir ]
-    and external_base, external_dir =
-      match OpamFilename.dir_is_empty external_dir with
-      | None | Some (true) -> [], []
-      | Some (false) -> ["external"], [ external_dir ]
-    in (opam_base @ external_base), (opam_dir @ external_dir)
-  in
   OpamConsole.formatted_msg "Bundle created.\n";
   let open Installer_config in
   (bundle_dir,
@@ -359,19 +348,14 @@ let create_bundle ~global_state ~switch_state ~env ~tmp_dir opam_oui_conf
      version = wix_version ~opam_oui_conf package;
      description = package_description ~opam package;
      manufacturer = String.concat ", " (OpamFile.OPAM.maintainer opam);
-     wix_tags = (match OpamFile.OPAM.tags opam with [] -> ["ocaml"] | ts -> ts );
      exec_files = List.map OpamFilename.Base.to_string exe_bases;
+     manpages = Installer_config.manpages_of_list manpages_paths;
+     environment = package_environment ~opam_oui_conf ~embedded_dirs ~embedded_files;
+     wix_tags = (match OpamFile.OPAM.tags opam with [] -> ["ocaml"] | ts -> ts );
      wix_icon_file = opam_oui_conf.c_images.ico;
      wix_dlg_bmp_file = opam_oui_conf.c_images.dlg;
      wix_banner_bmp_file = opam_oui_conf.c_images.ban;
      wix_license_file = None; (* TODO *)
-     wix_environment =
-       package_environment ~opam_oui_conf ~embedded_dirs ~embedded_files;
-     wix_embedded_dirs = embedded_dirs ;
-     wix_additional_embedded_name = additional_embedded_name ;
-     wix_embedded_files = embedded_files ;
-     wix_additional_embedded_dir = additional_embedded_dir;
-     manpages = Installer_config.manpages_of_list manpages_paths;
      macos_bundle_id = None; (* TODO *)
      macos_symlink_dirs = []; (* TODO *)
    })

--- a/src/oui_lib/wix_backend.ml
+++ b/src/oui_lib/wix_backend.ml
@@ -79,12 +79,11 @@ let create_bundle ?(keep_wxs=false) ~tmp_dir ~bundle_dir
       description = desc.description;
       keywords = String.concat " " desc.wix_tags;
       directory = OpamFilename.Dir.to_string bundle_dir;
-      (* wix_exec_file; wix_dlls; wix_embedded_dirs = []; wix_embedded_files = []; *)
       shortcuts = [];
       environment =
         List.map (fun (var_name, var_value) ->
             { var_name; var_value; var_part = All }
-          ) desc.wix_environment;
+          ) desc.environment;
       registry = [];
       icon;
       banner;

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -37,16 +37,12 @@ let make_config
   ; description = ""
   ; manufacturer = ""
   ; manpages
+  ; environment = []
   ; wix_tags = []
   ; wix_icon_file = None
   ; wix_dlg_bmp_file = None
   ; wix_banner_bmp_file = None
   ; wix_license_file = None
-  ; wix_embedded_dirs = []
-  ; wix_additional_embedded_name = []
-  ; wix_additional_embedded_dir = []
-  ; wix_embedded_files = []
-  ; wix_environment = []
   ; macos_bundle_id = None
   ; macos_symlink_dirs = []
   }


### PR DESCRIPTION
The embedded_files/dirs and additional_embedded_files/dirs fields are no longer useful. They come from the legacy config file, which required special handling with the old WiX backend. With the WiX 6 backend, this special handling is no longer required.

Note however the OPAM frontend still performs the required file copy operations to properly handle these embedded files and directories.