### PR TITLE
use right branch on nix CI

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -28,7 +28,6 @@ jobs:
 
           nix-shell --run "
             ODOC_WARN_ERROR=true
-            dune build @fmt &&
             dune build @doc &&
             dune build @install &&
             dune runtest


### PR DESCRIPTION
It explains why the CI was not starting. :-)

It should fail until the latest version of opam libs are in nixpkgs.