### PR TITLE
Allow plugins libs to overlap within a bundle

### DIFF
--- a/src/oui_lib/sh_script.ml
+++ b/src/oui_lib/sh_script.ml
@@ -19,6 +19,7 @@ type condition =
   | File_exists of string
   | Is_not_root
   | And of condition * condition
+  | Not of condition
 
 let (&&) c1 c2 = And (c1, c2)
 
@@ -96,6 +97,8 @@ let rec pp_sh_condition fmtr condition =
     Format.fprintf fmtr "%a && %a"
       pp_sh_condition c1
       pp_sh_condition c2
+  | Not (And _ as c) -> Format.fprintf fmtr "! (%a)" pp_sh_condition c
+  | Not c -> Format.fprintf fmtr "! %a" pp_sh_condition c
 
 let rec pp_sh_command ~indent fmtr command =
   let indent_str = String.make indent ' ' in

--- a/src/oui_lib/sh_script.mli
+++ b/src/oui_lib/sh_script.mli
@@ -19,6 +19,7 @@ type condition =
   | File_exists of string
   | Is_not_root
   | And of condition * condition
+  | Not of condition
 
 val (&&) : condition -> condition -> condition
 

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -85,6 +85,12 @@ let%expect_test "install_script: simple" =
         exit 1
       fi
     }
+    check_lib() {
+      if [ -e "$1" ] && ! [ -d "$1" ] && ! [ -L "$1" ]; then
+        printf '%s\n' "$1 already exists and does not appear to be a library! Aborting" >&2
+        exit 1
+      fi
+    }
     if [ -d "/usr/local/share/man" ]; then
       MAN_DEST="/usr/local/share/man"
     else
@@ -151,6 +157,12 @@ let%expect_test "install_script: plugin_dirs dumped in install.conf" =
     check_available() {
       if [ -e "$1" ]; then
         printf '%s\n' "$1 already exists on the system! Aborting" >&2
+        exit 1
+      fi
+    }
+    check_lib() {
+      if [ -e "$1" ] && ! [ -d "$1" ] && ! [ -L "$1" ]; then
+        printf '%s\n' "$1 already exists and does not appear to be a library! Aborting" >&2
         exit 1
       fi
     }
@@ -222,6 +234,12 @@ let%expect_test "install_script: install plugins" =
         exit 1
       fi
     }
+    check_lib() {
+      if [ -e "$1" ] && ! [ -d "$1" ] && ! [ -L "$1" ]; then
+        printf '%s\n' "$1 already exists and does not appear to be a library! Aborting" >&2
+        exit 1
+      fi
+    }
     load_conf() {
       var_prefix="$2"
       conf="$1"
@@ -280,8 +298,8 @@ let%expect_test "install_script: install plugins" =
     check_available $app_a_plugins/name
     check_available $app_b_lib/app-b-name
     check_available $app_b_plugins/name
-    check_available $app_b_lib/dep-a
-    check_available $app_b_lib/dep-b
+    check_lib $app_b_lib/dep-a
+    check_lib $app_b_lib/dep-b
     printf "Proceed? [y/N] "
     read ans
     case "$ans" in
@@ -300,12 +318,20 @@ let%expect_test "install_script: install plugins" =
     find . -mindepth 1 -maxdepth 1 ! -name 'install.sh' -exec cp -rp {} /opt/t-name \;
     echo "Installing plugin app-a-name to app-a..."
     ln -s /opt/t-name/lib/app-a/plugins/name $app_a_plugins/name
-    ln -s /opt/t-name/lib/app-a-name $app_a_lib/app-a-name
+    if ! [ -L "$app_a_lib/app-a-name" ] && ! [ -d "$app_a_lib/app-a-name" ]; then
+      ln -s /opt/t-name/lib/app-a-name $app_a_lib/app-a-name
+    fi
     echo "Installing plugin app-b-name to app-b..."
     ln -s /opt/t-name/lib/app-b/plugins/name $app_b_plugins/name
-    ln -s /opt/t-name/lib/app-b-name $app_b_lib/app-b-name
-    ln -s /opt/t-name/lib/dep-a $app_b_lib/dep-a
-    ln -s /opt/t-name/lib/dep-b $app_b_lib/dep-b
+    if ! [ -L "$app_b_lib/app-b-name" ] && ! [ -d "$app_b_lib/app-b-name" ]; then
+      ln -s /opt/t-name/lib/app-b-name $app_b_lib/app-b-name
+    fi
+    if ! [ -L "$app_b_lib/dep-a" ] && ! [ -d "$app_b_lib/dep-a" ]; then
+      ln -s /opt/t-name/lib/dep-a $app_b_lib/dep-a
+    fi
+    if ! [ -L "$app_b_lib/dep-b" ] && ! [ -d "$app_b_lib/dep-b" ]; then
+      ln -s /opt/t-name/lib/dep-b $app_b_lib/dep-b
+    fi
     {
       printf '%s\n' "version=t.version"
       printf '%s\n' "app_a_lib=$app_a_lib"
@@ -519,6 +545,12 @@ let%expect_test "install_script: binary in sub folder" =
     check_available() {
       if [ -e "$1" ]; then
         printf '%s\n' "$1 already exists on the system! Aborting" >&2
+        exit 1
+      fi
+    }
+    check_lib() {
+      if [ -e "$1" ] && ! [ -d "$1" ] && ! [ -L "$1" ]; then
+        printf '%s\n' "$1 already exists and does not appear to be a library! Aborting" >&2
         exit 1
       fi
     }


### PR DESCRIPTION
This allows users to define multiple plugins that point to the same library folder. This is something that's possible to do since two different plugins can point to two different libs in the same package but those are both in the same directory in the `lib/` folder. Since we install folders rather than fine grained libraries when installing plugins (because we in fact install symlink to those directories), we need to support this somehow.

This makes it so libraries are installed only if there is no library sitting there already.
This also allow us to let plugins from different installers share dependencies.
The two cases are handled slightly differently:
1. the plugin's library must not be present before the install but during the installation, it's only installed once.
2. dependency libraries can be present before installation, we simply check they are a directory or a symlink and do not overwrite them if that's the case. This could potentially be later refined with checks on the lib META files to ensure the version is consistent for instance.