### PR TITLE
Finish plugin support under WiX

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,7 +91,7 @@ jobs:
         run: opam install .
 
       - name: "Test: install target opam package"
-        run: opam install ocp-indent.1.8.1
+        run: opam install ocp-indent.1.9.0
 
       - name: "Test: create package"
         run: |
@@ -100,7 +100,7 @@ jobs:
 
       - name: "Test: install package"
         run: |
-          msiexec /i ocp-indent-1.8.1.msi /qn /L*v wixlog.txt ALLUSERS=2 MSIINSTALLPERUSER= 
+          msiexec /i ocp-indent-1.9.0.msi /qn /L*v wixlog.txt ALLUSERS=2 MSIINSTALLPERUSER= 
 
       - name: "Test: execute binary"
         run: |
@@ -125,4 +125,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: package.msi
-          path: ocp-indent-1.8.1.msi
+          path: ocp-indent-1.9.0.msi

--- a/data/wix/WixUI_CustomPlugin.wxs
+++ b/data/wix/WixUI_CustomPlugin.wxs
@@ -22,8 +22,9 @@
 
         <CustomAction Id="C_WixSetAppFolderPerUser" Property="WixAppFolder" Value="WixPerUserFolder" Execute="immediate" />
         <CustomAction Id="C_WixSetAppFolderPerMachine" Property="WixAppFolder" Value="WixPerMachineFolder" Execute="immediate" />
-        <CustomAction Id="C_WixSetDefaultPerUserFolder" Property="WixPerUserFolder" Value="[WIXPERUSERAPPFOLDER]\[ApplicationFolderName]" Execute="immediate" />
-        <CustomAction Id="C_WixSetDefaultPerMachineFolder" Property="WixPerMachineFolder" Value="[WIXPERMACHINEAPPFOLDER]\[ApplicationFolderName]" Execute="immediate" />
+        <!-- or [WIXPERUSERAPPFOLDER]\[ApplicationFolderName] / [WIXPERMACHINEAPPFOLDER]\[ApplicationFolderName] -->
+        <CustomAction Id="C_WixSetDefaultPerUserFolder" Property="WixPerUserFolder" Value="[WIXPERUSERAPPFOLDER]" Execute="immediate" />
+        <CustomAction Id="C_WixSetDefaultPerMachineFolder" Property="WixPerMachineFolder" Value="[WIXPERMACHINEAPPFOLDER]" Execute="immediate" />
         <CustomAction Id="C_WixSetPerUserFolder" Property="APPLICATIONFOLDER" Value="[WixPerUserFolder]" Execute="immediate" />
         <CustomAction Id="C_WixSetPerMachineFolder" Property="APPLICATIONFOLDER" Value="[WixPerMachineFolder]" Execute="immediate" />
         <CustomAction Id="C_WixUnsetALLUSERS" Property="ALLUSERS" Value="{}" Execute="immediate" />

--- a/src/opam-oui/main.ml
+++ b/src/opam-oui/main.ml
@@ -91,8 +91,8 @@ let create_bundle cli =
            save_bundle_and_conf ~installer_config ~bundle_dir dst
          | Some Wix ->
            let dst = OpamFilename.of_string output in
-           Wix_backend.create_bundle ~keep_wxs ~tmp_dir ~bundle_dir
-             installer_config dst
+           Wix_backend.create_installer ~keep_wxs ~tmp_dir ~installer_config
+             ~bundle_dir dst
          | Some Makeself ->
            let dst = OpamFilename.of_string output in
            Makeself_backend.create_installer ~installer_config ~bundle_dir dst

--- a/src/oui/build.ml
+++ b/src/oui/build.ml
@@ -33,7 +33,7 @@ let run keep_wxs backend installer_config bundle_dir output
          OpamFilename.copy_dir ~src ~dst:bundle_dir;
          match backend with
          | Wix ->
-           Wix_backend.create_bundle ~keep_wxs ~tmp_dir ~bundle_dir installer_config dst
+           Wix_backend.create_installer ~keep_wxs ~tmp_dir ~installer_config ~bundle_dir dst
          | Makeself ->
            Makeself_backend.create_installer ~installer_config ~bundle_dir dst
          | Pkgbuild ->

--- a/src/oui_lib/system.ml
+++ b/src/oui_lib/system.ml
@@ -98,7 +98,7 @@ let call_inner : type a. a command -> a -> string * string list =
     let wix = "wix.exe" in
     let args = "build" ::
       List.flatten (List.map (fun e -> ["-ext"; e]) wix_exts)
-      @ wix_files @ ["-o"; wix_out]
+      @ wix_files @ ["-o"; wix_out; "-pdbtype"; "none"]
     in
     wix, args
   | Makeself, { archive_dir; installer; description; startup_script } ->

--- a/src/oui_lib/wix.mli
+++ b/src/oui_lib/wix.mli
@@ -18,8 +18,8 @@ end
 (** Information module used to generated main wxs document. *)
 type info = {
 
-  (* Indicates this is a plugin *)
-  is_plugin: bool;
+  (* Indicates this is a plugin for the given application *)
+  plugin_for: string option;
 
   (* Package unique ID (replaces GUID) *)
   unique_id: string;
@@ -28,10 +28,7 @@ type info = {
   manufacturer: string;
 
   (* Package name used as product name *)
-  short_name: string;
-
-  (* More descriptive package name *)
-  long_name: string;
+  name: string;
 
   (* Package version *)
   version: string;
@@ -64,7 +61,7 @@ type info = {
   background: string;
 
   (* License filename (absolute) *)
-  license: string;
+  license: string option;
 }
 
 and shortcut =
@@ -78,7 +75,7 @@ and var = {
 }
 
 and key = {
-  key_name: string;
+  key_name: string option;
   key_type: string;
   key_value: string;
 }

--- a/src/oui_lib/wix_backend.mli
+++ b/src/oui_lib/wix_backend.mli
@@ -10,10 +10,10 @@
 
 val vars : Installer_config.vars
 
-val create_bundle :
+val create_installer :
   ?keep_wxs: bool ->
   tmp_dir:OpamFilename.Dir.t ->
+  installer_config: Installer_config.internal ->
   bundle_dir:OpamFilename.Dir.t ->
-  Installer_config.internal ->
   OpamFilename.t ->
   unit


### PR DESCRIPTION
This adds the missing bits to properly build a plugin installer with WiX.
I was able to build Windows installers for Frama-C and the EVA plugin.

Some notes:
- I had to disable the executable permission check for Windows (irrelevant under this OS)
- I had to add a check for Unique ID validity (does not allow `-` under WiX)
- to detect whether we create an application or plugin installer, I relied on the presence of the `plugins` field, but this seems hackish (the current format of the config file allows specifying plugins for different apps in the same file, we have to do something about it)
- I completely ignore the `lib_dir` and `plugin_dir` fields, I solely rely on the bundle directory to be properly built ; I hope this is right
- we have to do something about the different executable extension under Windows - if we want to use the same JSON file for all backends