### PR TITLE
Allow disabling dependency resolution and symlinks per binary

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -37,10 +37,13 @@ are:
 - `fullname`, **string**, **required**: *TODO* (remove or make WiX specific?)
 - `version`, **string**, **required**: the version of the app. *Example:*
   `"1.0.0"`. WiX backend requires that in `major.minor.patch`, `major`, `minor` and `patch` are strictly numerical.
-- `exec_files`, **string array**, **optional**: The list of executables to
-  install from the bundle. Should be a list of paths, relative to the bundle
-  root, pointing to executable files that should be installed and made available
-  to the user. *Example:* `["bin/oui", "bin/opam-oui"]`.
+- `exec_files`, **(string | object) array**, **optional**: The list of executables to
+  install from the bundle. Each executable is described either by a simple string or
+  an object. Either way, these contain paths, relative to the bundle root, pointing
+  to executable files that should be installed and made available to the user.
+  *Example (strings only):* `["bin/oui", "bin/opam-oui"]`.
+  See the [exec_files object section](#exec_files-object) for the object
+  format.
 - `manpages`, **object**, **optional**: A JSON object describing where manpages
   are located within the bundle so they can be properly installed on the target
   system. See the [manpages object section](#manpages-object) for the object
@@ -83,6 +86,28 @@ are:
   in `Contents/`. Used by macOS backend only. See
   [macOS / Application Bundle section](#macos--application-bundle) for details.
   *Example:* `["lib", "share"]`.
+
+### exec_files object
+
+To give more control over the actions performed on executables files to be
+installed, an object can be use instead of a plain string.
+
+It contains the following fields:
+- `path`, **string**, **required**: Paths to the executable file, relative to
+  the bundle root
+- `symlink`, **boolean**, **optional**: Whether to create symlinks to the
+  executable in `/usr/local/bin`. True by default.
+- `deps`, **boolean**, **optional**: Whether to resolve shared library
+  dependencies on the executable. True by default.
+
+*Example:*
+```json
+{
+  "path": "bin/myapp",
+  "symlink": true,
+  "deps": true
+}
+```
 
 ### manpages object
 

--- a/src/oui_lib/installer_config.mli
+++ b/src/oui_lib/installer_config.mli
@@ -8,6 +8,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type exec_file = {
+    path : string;
+    symlink : bool; [@default true]
+    deps : bool; [@default true]
+  }
+
 type man_section =
   | Man_dir of string
   | Man_files of string list
@@ -54,7 +60,7 @@ type ('manpages, 'string_with_vars) t = {
     fullname : string ;
     version : string;
     (** Package version used as part of product name. Deduced from opam file *)
-    exec_files : string list; (** Filenames of bundled .exe binary. *)
+    exec_files : exec_file list; (** Filenames of bundled .exe binary. *)
     manpages : 'manpages option; (** Paths to manpages, split by sections. *)
     environment : (string * 'string_with_vars) list;
     (** Environement variables to set/unset in Windows terminal on install/uninstall respectively. *)

--- a/src/oui_lib/macos_app_bundle.ml
+++ b/src/oui_lib/macos_app_bundle.ml
@@ -30,7 +30,7 @@ let create ~installer_config ~work_dir =
   let binary_name = match installer_config.exec_files with
     | [] -> OpamConsole.error_and_exit `Bad_arguments
               "No exec_files specified in config"
-    | binary :: _ -> Filename.basename binary
+    | binary :: _ -> Filename.basename binary.path
   in
   let app_bundle_dir = work_dir / (app_name_cap ^ ".app") in
   let contents = app_bundle_dir / "Contents" in

--- a/src/oui_lib/opam_frontend.ml
+++ b/src/oui_lib/opam_frontend.ml
@@ -357,13 +357,18 @@ let create_bundle ~global_state ~switch_state ~env ~tmp_dir opam_oui_conf
   OpamConsole.formatted_msg "Bundle created.\n";
   let open Installer_config in
   let name = OpamPackage.Name.to_string (OpamPackage.name package) in
+  let exec_files =
+    List.map (fun x ->
+        { path = OpamFilename.Base.to_string x; symlink = true; deps = true }
+      ) exe_bases
+  in
   let wix_manufacturer = String.concat ", " (OpamFile.OPAM.maintainer opam) in
   (bundle_dir,
    {
      name;
      fullname = OpamPackage.to_string package;
      version = wix_version ~opam_oui_conf package;
-     exec_files = List.map OpamFilename.Base.to_string exe_bases;
+     exec_files;
      manpages = manpages_paths;
      environment = package_environment ~opam_oui_conf ~embedded_dirs ~embedded_files;
      unique_id = sanitize_id (String.concat "." [wix_manufacturer; name]);

--- a/src/oui_lib/pkgbuild_backend.ml
+++ b/src/oui_lib/pkgbuild_backend.ml
@@ -82,7 +82,7 @@ let create_installer
   let binary_src = match installer_config.exec_files with
     | [] -> OpamConsole.error_and_exit `Bad_arguments
               "No exec_files specified in config"
-    | binary :: _ -> bundle_dir // binary
+    | binary :: _ -> bundle_dir // binary.path
   in
   let binary_dst = Macos_app_bundle.install_binary bundle ~binary_path:binary_src in
 

--- a/src/oui_lib/wix_backend.ml
+++ b/src/oui_lib/wix_backend.ml
@@ -24,8 +24,8 @@ let check_wix_installed () =
     raise @@ System.System_error
       (Format.sprintf "Wix binaries couldn't be found.")
 
-let add_dlls_to_bundle ~bundle_dir binary =
-  let binary = System.maybe_exe ~dir:bundle_dir ~path:binary in
+let add_dlls_to_bundle ~bundle_dir (binary : Installer_config.exec_file) =
+  let binary = System.maybe_exe ~dir:bundle_dir ~path:binary.path in
   let dlls = Win_ldd.get_dlls (bundle_dir // binary) in
   match dlls with
   | [] -> ()
@@ -35,6 +35,10 @@ let add_dlls_to_bundle ~bundle_dir binary =
       let bin_dir = OpamFilename.Op.(bundle_dir / "bin") in
       OpamFilename.mkdir bin_dir;
       List.iter (fun dll -> OpamFilename.copy_in dll bin_dir) dlls
+
+let add_dlls_to_bundle ~bundle_dir (binary : Installer_config.exec_file) =
+  if binary.deps then
+    add_dlls_to_bundle ~bundle_dir binary
 
 let data_file ~tmp_dir ~default:(name, content) data_path =
   match data_path with

--- a/tests/oui_lib/test_makeself_backend.ml
+++ b/tests/oui_lib/test_makeself_backend.ml
@@ -71,7 +71,8 @@ let%expect_test "install_script: simple" =
   in
   let config =
     make_config ~name:"aaa" ~version:"x.y.z"
-      ~exec_files:["aaa-command"; "aaa-utility"]
+      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
+                   { path = "aaa-utility"; symlink = true; deps = true } ]
       ~manpages
       ()
   in
@@ -474,7 +475,8 @@ let%expect_test "uninstall_script: simple" =
   in
   let config =
     make_config ~name:"aaa"
-      ~exec_files:["aaa-command"; "aaa-utility"]
+      ~exec_files:[{ path = "aaa-command"; symlink = true; deps = true };
+                   { path = "aaa-utility"; symlink = true; deps = true } ]
       ~manpages
       ()
   in
@@ -540,7 +542,7 @@ let%expect_test "uninstall_script: simple" =
 (* Regression test that ensures that if the binaries are not at the bundle's
    root, the symlink are still installed correctly. *)
 let%expect_test "install_script: binary in sub folder" =
-  let config = make_config ~exec_files:["bin/do"] () in
+  let config = make_config ~exec_files:[{ path = "bin/do"; symlink = true; deps = true }] () in
   let install_script = Makeself_backend.install_script config in
   Format.printf "%a" Sh_script.pp_sh install_script;
   [%expect {|
@@ -599,7 +601,7 @@ let%expect_test "install_script: binary in sub folder" =
 (* Regression test that ensures that if the binaries are not at the bundle's
    root, the symlinks are correctly removed by the uninstall script. *)
 let%expect_test "uninstall_script: binary in sub folder" =
-  let config = make_config ~exec_files:["bin/do"] () in
+  let config = make_config ~exec_files:[{ path = "bin/do"; symlink = true; deps = true }] () in
   let uninstall_script = Makeself_backend.uninstall_script config in
   Format.printf "%a" Sh_script.pp_sh uninstall_script;
   [%expect {|
@@ -642,7 +644,7 @@ let%expect_test "uninstall_script: binary in sub folder" =
 let%expect_test "install_script: set environment for binaries" =
   let config =
     make_config
-      ~exec_files:["bin/app"]
+      ~exec_files:[{ path = "bin/app"; symlink = true; deps = true }]
       ~environment:[("VAR1", "value1"); ("VAR2", "$INSTALL_PATH/lib")]
       ()
   in


### PR DESCRIPTION
This PR allow to disable dependency resolution and symlinks per binary.
The JSON syntax has been extended, allowing to specify an object `{ name: ..., symlink: ..., deps: ... }` instead of a single string (which remains possible).  When `deps` is false, no dependency resolution is performed on the binary. When `symlink` is false, no symlink is created for the binary. By default, when specifying only the binary name using a string, both `symlink` and `deps` are true.

This should tackle #86 .